### PR TITLE
Add box for custom css in heads up display admin settings page

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -43,7 +43,7 @@ function headsup_register_settings() {
 		'headsup_callback_font',
 		'headsup_plugin',
 		'api_settings',
-		[ 'id' => 'font_style', 'label' => 'Custom display location' ]
+		[ 'id' => 'font-style', 'label' => 'Custom display location' ]
 	);
 
 	add_settings_field(
@@ -53,6 +53,15 @@ function headsup_register_settings() {
 		'headsup_plugin',
 		'api_settings',
 		[ 'id' => 'location', 'label' => 'Custom display location' ]
+	);
+
+	add_settings_field(
+		'headsup_callback_css',
+		'Custom CSS',
+		'headsup_callback_css',
+		'headsup_plugin',
+		'api_settings',
+		[ 'id' => 'custom-css', 'label' => '' ]
 	);
 }
 add_action( 'admin_init', 'headsup_register_settings' );
@@ -66,6 +75,12 @@ function headsup_options_font_default() {
 
 function headsup_options_location_default() {
 	return array( 'location' => 'none' );
+}
+
+function headsup_options_css_default() {
+	return array(
+		'custom-css' => '{font-size: 12px}',
+	);
 }
 
 // callback: font radio field
@@ -117,6 +132,18 @@ function headsup_callback_location( $args ) {
 		echo '<span>'. $label .'</span></label><br />';
 
 	}
+}
+
+//callback: font size text field
+function headsup_callback_css ( $args ) {
+	$options = get_option( 'headsup_options', headsup_options_css_default());
+	
+	$id    = isset( $args['id'] )    ? $args['id']    : '';
+	$label = isset( $args['label'] ) ? $args['label'] : '';
+	
+	echo '<label><textarea name="headsup_options['. $id .']" cols="30" rows="7">' . $options[$id] . '</textarea>';
+	echo '<span>'. $label .'</span></label><br />';
+
 }
 
 // validate plugin settings

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -58,7 +58,6 @@ function headsup_register_settings() {
 	add_settings_field(
 		'headsup_callback_css',
 		'Custom CSS',
-		'headsup_callback_css',
 		'headsup_plugin',
 		'api_settings',
 		[ 'id' => 'custom-css', 'label' => '' ]

--- a/core-functions.php
+++ b/core-functions.php
@@ -15,15 +15,21 @@ function headsup_function() {
   $recentAuthorUsername = get_user_by('id', $recentAuthorId)->user_login;
   $countUsers = count_users();
 
-  $styleInfo = get_option('headsup_options')['font_style'];
+  $cssInfo = get_option('headsup_options')['custom-css'];
+
+  $styleInfo = get_option('headsup_options')['font-style'];
   $styling = ['None' => ['',''], 'Bold' => ['<b>','</b>'], 'Italic' => ['<i>','</i>']];
 
+  echo '<style>#headsup' . $cssInfo . '</style>';
+
+  echo '<div id="headsup">';
   echo "{$styling[$styleInfo][0]}Published Posts: " . $numPosts . "{$styling[$styleInfo][1]}<br>";
   echo "{$styling[$styleInfo][0]}Published Pages: " . $numPages . "{$styling[$styleInfo][1]}<br>";
   echo "{$styling[$styleInfo][0]}Total Comments: " . $numComments . "{$styling[$styleInfo][1]}<br>";
   echo "{$styling[$styleInfo][0]}Most Recent Post: " . date( 'jS F, Y', strtotime( $recentPosts[0]['post_date'] ) ) . "{$styling[$styleInfo][1]}<br>";
   echo "{$styling[$styleInfo][0]}Most Recent Author: " . $recentAuthorUsername . "{$styling[$styleInfo][1]}<br>";
   echo "{$styling[$styleInfo][0]}Total Users: " . $countUsers['total_users'] . "{$styling[$styleInfo][1]}<br>";
+  echo "</div>";
 }
 
 /**


### PR DESCRIPTION
This pull requests adds in a html textarea box where site admins can add custom css that will be injected into the heads up display that is shown on the dashboard.